### PR TITLE
Updated to work without the OpenExchangeRates.

### DIFF
--- a/package/README.txt
+++ b/package/README.txt
@@ -11,7 +11,6 @@ Currently two different workflows are supported who enable an easy management of
 
 Requirements
 ------------
-* Open Exchange Rates library for SugarCRM (http://github.com/jcsmorais/open-exchange-rates-lib-for-sugarcrm)
 * SugarCRM 6.3+
 
 

--- a/package/copy/custom/modules/Currencies/ExchangeRateUpdater.php
+++ b/package/copy/custom/modules/Currencies/ExchangeRateUpdater.php
@@ -7,7 +7,7 @@
  *
  * Copyright (c) 2012 João Morais and 
  *               2014 Kristofer Tingdahl (only minor changes)
- * http://github.com/tingdahl/currencies-exchange-rate-updater
+ * http://github.com/jcsmorais/currencies-exchange-rate-updater
  *
  * For the full copyright and license information, please view the LICENSE.txt
  * file that was distributed with this source code.

--- a/package/copy/custom/modules/Currencies/ExchangeRateUpdater.php
+++ b/package/copy/custom/modules/Currencies/ExchangeRateUpdater.php
@@ -69,7 +69,7 @@ class ExchangeRateUpdater {
 		{
 		    if(preg_match("/rate='([[:graph:]]+)'/",$line,$rate))
 		    {
-			$latestRates[$iso4217[1]] = $rate[1];
+			$latestRates[$iso4217[1]] = (float) $rate[1];
 		    }
 		}
 	    }

--- a/package/manifest.php
+++ b/package/manifest.php
@@ -34,10 +34,7 @@ $manifest = array(
     'author' => 'João Morais',
     'description' => 'Currencies Exchange Rate Updater is a SugarCRM package designed to ease the process of updating active currencies exchange rates with the help of external data sources.',
     'dependencies' => array(
-        array(
-            'id_name' => 'oer',
-            'version' => '0.0.1'
-        )
+        array()
     ),
     'is_uninstallable' => true,
     'name' => 'Currencies Exchange Rate Updater',

--- a/package/manifest.php
+++ b/package/manifest.php
@@ -33,17 +33,12 @@ $manifest = array(
     ),
     'author' => 'João Morais',
     'description' => 'Currencies Exchange Rate Updater is a SugarCRM package designed to ease the process of updating active currencies exchange rates with the help of external data sources.',
-    'dependencies' => array(
-        array(
-            'id_name' => 'oer',
-            'version' => '0.0.1'
-        )
-    ),
+    'dependencies' => array(),
     'is_uninstallable' => true,
     'name' => 'Currencies Exchange Rate Updater',
     'published_date' => '2012-10-30',
     'type' => 'module',
-    'version' => '0.0.1'
+    'version' => '0.0.2'
 );
 
 $installdefs = array(


### PR DESCRIPTION
Hi,

I had code that did the same thing as your code, but took the information from ECB Reference dates. (https://www.ecb.europa.eu/stats/exchange/eurofxref/html/index.en.html).

I am contractually obliged to use these rates in my quotes, hence I'm not interested in the OER ones. If OER is installed, it will still be used.

If you accept my changes, perhaps version should be updated to 0.0.2 (or why not 1.0.0 ;-) )

Cheers,

Kristofer
